### PR TITLE
fix: allow derived projects to keep their own tests directory

### DIFF
--- a/.project/checkpoints/CP-20260907-008.yml
+++ b/.project/checkpoints/CP-20260907-008.yml
@@ -1,0 +1,46 @@
+schema_version: 1.0.0
+checkpoint_id: CP-20260907-008
+created_at: '2026-09-07T21:44:32Z'
+workstream: WS-001
+task: T017
+branch: fix/021-derived-tests-dir
+head: 66b8760d722c901553352404a20ab934707c4b51
+working_tree:
+  status: dirty
+  modified_paths:
+  - M src/engineering_playbook/core.py
+completed_work:
+- Implemented playbook artifacts or recorded current progress.
+commands:
+- uv sync --locked
+- uv run ruff format --check .
+- uv run ruff check .
+- uv run pyright
+- uv run pytest
+- uv run python scripts/verify.py
+- uv run python scripts/doctor.py
+- uv run python scripts/resume.py
+- uv run python scripts/reconcile.py
+- uv run python scripts/bootstrap.py
+- uv run python scripts/delivery.py status
+- uv run python scripts/checkpoint.py
+- engineering-playbook checkpoint
+validation:
+  passed:
+  - uv sync --locked
+  - uv run ruff format --check .
+  - uv run ruff check .
+  - uv run pyright
+  - uv run pytest
+  - uv run python scripts/verify.py
+  - uv run python scripts/doctor.py
+  - uv run python scripts/resume.py
+  - uv run python scripts/reconcile.py
+  - uv run python scripts/bootstrap.py
+  - uv run python scripts/delivery.py status
+  - uv run python scripts/checkpoint.py
+  - engineering-playbook checkpoint
+  failed: []
+  not_run: []
+blockers: []
+next_action: Retomar com uv run python scripts/resume.py antes de novas mudancas.

--- a/.project/state.yml
+++ b/.project/state.yml
@@ -1,15 +1,15 @@
 schema_version: 1.0.0
-updated_at: '2026-09-07T21:21:07Z'
+updated_at: '2026-09-07T21:44:32Z'
 active_workstream: WS-001
-current_branch: feat/020-cli-packaging
+current_branch: fix/021-derived-tests-dir
 current_phase: converge
 status: converged
 active_specification: specs/001-engineering-playbook/spec.md
 active_plan: specs/001-engineering-playbook/plan.md
 active_tasks: specs/001-engineering-playbook/tasks.md
 active_task: T017
-last_checkpoint: .project/checkpoints/CP-20260907-007.yml
-last_verified_commit: 24e3d92b4c8866732aa6b98bd630f414e4cb93b1
+last_checkpoint: .project/checkpoints/CP-20260907-008.yml
+last_verified_commit: 66b8760d722c901553352404a20ab934707c4b51
 validation:
   passed:
   - uv sync --locked

--- a/src/engineering_playbook/core.py
+++ b/src/engineering_playbook/core.py
@@ -596,7 +596,8 @@ def verify_root(root: Path) -> CheckResult:
         for forbidden in [
             "bootstrap-engineering-template.yml",
             "specs/001-engineering-playbook",
-            "tests",
+            "tests/unit/test_core.py",
+            "tests/fixtures/requirements",
             ".project/distribution.yml",
         ]:
             result.add(


### PR DESCRIPTION
## Summary

fix: allow derived projects to keep their own tests directory

## Problem and motivation

Prepared by `scripts/delivery.py prepare` from repository state.

## Specification and requirements

See active `.project/state.yml`, specs, ADRs and PRD references.

## Changes

- `src/engineering_playbook/core.py`

## Validation evidence

- `uv run python scripts/resume.py`
- `uv run python scripts/doctor.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest`
- `uv run python scripts/verify.py`

## Benchmarks when applicable

N/A - not applicable unless performance requirements changed.

## Risks and limitations

Remote operations are not executed by prepare.

## Reviewer checklist

- [ ] Requirements trace to tasks and evidence.
- [ ] Tests and validations listed were actually executed.
- [ ] No secrets, personal data or invented evidence.
- [ ] State and checkpoint are updated when applicable.
