### PR TITLE
fix: write commit message to a file to avoid Windows argv limits

### DIFF
--- a/.project/checkpoints/CP-20260907-009.yml
+++ b/.project/checkpoints/CP-20260907-009.yml
@@ -1,0 +1,46 @@
+schema_version: 1.0.0
+checkpoint_id: CP-20260907-009
+created_at: '2026-09-07T21:58:24Z'
+workstream: WS-001
+task: T017
+branch: fix/022-commit-message-file
+head: 89990676bd649e02b782372e5ee8910dd3c96e19
+working_tree:
+  status: dirty
+  modified_paths:
+  - M src/engineering_playbook/delivery.py
+completed_work:
+- Implemented playbook artifacts or recorded current progress.
+commands:
+- uv sync --locked
+- uv run ruff format --check .
+- uv run ruff check .
+- uv run pyright
+- uv run pytest
+- uv run python scripts/verify.py
+- uv run python scripts/doctor.py
+- uv run python scripts/resume.py
+- uv run python scripts/reconcile.py
+- uv run python scripts/bootstrap.py
+- uv run python scripts/delivery.py status
+- uv run python scripts/checkpoint.py
+- engineering-playbook checkpoint
+validation:
+  passed:
+  - uv sync --locked
+  - uv run ruff format --check .
+  - uv run ruff check .
+  - uv run pyright
+  - uv run pytest
+  - uv run python scripts/verify.py
+  - uv run python scripts/doctor.py
+  - uv run python scripts/resume.py
+  - uv run python scripts/reconcile.py
+  - uv run python scripts/bootstrap.py
+  - uv run python scripts/delivery.py status
+  - uv run python scripts/checkpoint.py
+  - engineering-playbook checkpoint
+  failed: []
+  not_run: []
+blockers: []
+next_action: Retomar com uv run python scripts/resume.py antes de novas mudancas.

--- a/.project/state.yml
+++ b/.project/state.yml
@@ -1,15 +1,15 @@
 schema_version: 1.0.0
-updated_at: '2026-09-07T21:44:32Z'
+updated_at: '2026-09-07T21:58:24Z'
 active_workstream: WS-001
-current_branch: fix/021-derived-tests-dir
+current_branch: fix/022-commit-message-file
 current_phase: converge
 status: converged
 active_specification: specs/001-engineering-playbook/spec.md
 active_plan: specs/001-engineering-playbook/plan.md
 active_tasks: specs/001-engineering-playbook/tasks.md
 active_task: T017
-last_checkpoint: .project/checkpoints/CP-20260907-008.yml
-last_verified_commit: 66b8760d722c901553352404a20ab934707c4b51
+last_checkpoint: .project/checkpoints/CP-20260907-009.yml
+last_verified_commit: 89990676bd649e02b782372e5ee8910dd3c96e19
 validation:
   passed:
   - uv sync --locked

--- a/src/engineering_playbook/delivery.py
+++ b/src/engineering_playbook/delivery.py
@@ -316,7 +316,10 @@ def command_commit(args: argparse.Namespace) -> int:
         print(f"ERROR: invalid Conventional Commit title: {title}")
         return 1
     prepare = load_yaml(args.root / PREPARE_FILE)
-    completed = run(args.root, ["git", "commit", "-m", title, "-m", prepare["body"]])
+    message_file = args.root / ".project/delivery/commit-message.txt"
+    message_file.parent.mkdir(parents=True, exist_ok=True)
+    message_file.write_text(f"{title}\n\n{prepare['body']}", encoding="utf-8", newline="\n")
+    completed = run(args.root, ["git", "commit", "-F", str(message_file)])
     if completed.returncode != 0:
         print(completed.stderr.strip())
         return completed.returncode


### PR DESCRIPTION
## Summary

fix: write commit message to a file to avoid Windows argv limits

## Problem and motivation

Prepared by `scripts/delivery.py prepare` from repository state.

## Specification and requirements

See active `.project/state.yml`, specs, ADRs and PRD references.

## Changes

- `src/engineering_playbook/delivery.py`

## Validation evidence

- `uv run python scripts/resume.py`
- `uv run python scripts/doctor.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest`
- `uv run python scripts/verify.py`

## Benchmarks when applicable

N/A - not applicable unless performance requirements changed.

## Risks and limitations

Remote operations are not executed by prepare.

## Reviewer checklist

- [ ] Requirements trace to tasks and evidence.
- [ ] Tests and validations listed were actually executed.
- [ ] No secrets, personal data or invented evidence.
- [ ] State and checkpoint are updated when applicable.
